### PR TITLE
Implemented issue #1 #3 #4 and #10

### DIFF
--- a/webnote.py
+++ b/webnote.py
@@ -1,13 +1,19 @@
 import socket
 import re
 import json
-import urlparse
+from urlparse import parse_qs
+import sqlite3 as lite
+import httplib
+import base64
+#import string
 
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
 s.bind(('0.0.0.0', 8080))
 s.listen(1)
+loged = 0
+userloged = None
 
 while True:
     data = ''
@@ -21,6 +27,10 @@ while True:
             break
         data += new_data
 
+	print 'DATA ORIGINAL\r\n', data
+	
+	print '---------------------------------------'	
+
     request_match = \
             re.match(r'^([^ ]+) ([^ ]+) ([^ ]+)\r\n(.*)$', data, re.DOTALL)
     if request_match is not None:
@@ -28,10 +38,11 @@ while True:
         resource = request_match.group(2)
         protocol = request_match.group(3)
         data = request_match.group(4)
+	print data
         
     else:
         raise Exception('Cannot read request')
-
+	
     request_headers = dict()
 
     while True:
@@ -43,6 +54,7 @@ while True:
             field_name = field.group(1)
             field_body = field.group(2)
             request_headers[field_name.lower()] = field_body
+            print request_headers
             data = field.group(3)
         else:
             raise Exception('Cannot read request header')
@@ -50,18 +62,222 @@ while True:
     response = ''
 
     response += 'HTTP/1.1 200 OK\r\n'
-
+    
     try:
+        #print 'userloged = ', userloged
         with open('.notes') as note_file:
             note_dict = json.loads(note_file.read())
     except IOError:
         note_dict = dict()
+
+    note_list = []
+    for key in note_dict:
+            note_list.append(note_dict[key])
+    
+    try:
+        con = lite.connect('datas.db')
+        with con:
+            cur = con.cursor()
+            cur.execute("CREATE TABLE Notes(Id INTEGER PRIMARY KEY, Key TEXT UNIQUE NOT NULL, Note TEXT NOT NULL)")
+    except lite.OperationalError:
+        pass
+   
+
+    try:
+        con1 = lite.connect('datas.db')
+        with con1:
+            cur1 = con1.cursor()
+            cur1.execute("CREATE TABLE Users(Id INTEGER PRIMARY KEY, Name TEXT UNIQUE NOT NULL, Password TEXT NOT NULL)")
+    except lite.OperationalError:
+        pass
+
+    print loged
+    print userloged
+    print resource    
+
+    if resource == '/auth':
+        response += 'Content-Type: text/html; charset=utf-8\r\n'
+        response += '\r\n'
+        if method == 'GET':
+            response += """
+            <html>
+                <head>
+                    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+                </head>
+                <body>
+                <form action="/auth" method="POST">
+                    <h2>Insira seu usuario e senha!</h2>
+                    User: <input type="text" name="user"/>
+                    <br/>
+                    Password: <input type="text" name="password"/>
+                    <br/>
+                    <input type="submit" value="Add"/>
+                </form>
+                </body>
+            </html>
+            """
+        elif method == 'POST':
+            print data
+            new_dict = parse_qs(data)
+            username = new_dict['user'][0]
+            password = new_dict['password'][0]
+            trying = base64.encodestring('%s:%s' % (username, password)).replace('\n', '') 
+            con = lite.connect('datas.db')
+            username = str(username)
+            with con:
+                cur = con.cursor()
+                cur.execute('SELECT Password FROM Users WHERE Name=:name',{'name': username})
+                row = cur.fetchall()
+                if row == None:
+                    break
+                authent = row[0][0]
+                print authent
+            if trying == authent:
+                loged = 1
+                userloged = username
+                print 'USERLOGED = ', userloged
+                print loged
+                response = ''
+                response += 'HTTP/1.1 418 I\'m a teapot\r\n'
+                response += 'Content-Type: text/html; charset=utf-8\r\n'
+                response += '\r\n'
+                response += """
+                <html>
+                    <head>
+                        <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+                    </head>
+                    <body>
+                        <h1>Sucess!</h1>
+                    </body>
+                </html>
+                """
+            else:
+                response = ''
+                response += 'HTTP/1.1 401 Unauthorized\r\n'
+                response += 'Content-Type: text/html; charset=utf-8\r\n'
+                response += '\r\n'
+                response += """
+                <html>
+                    <head>
+                        <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+                    </head>
+                    <body>
+                        <h1>ERROR 401 - Unauthorized<h1>
+                    </body>
+                </html>
+                """
+
+    elif resource == '/register':
+        response += 'Content-Type: text/html; charset=utf-8\r\n'
+        response += '\r\n'
+        if method == 'GET':
+            response += """
+            <html>
+                <head>
+                    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+                </head>
+                <body>
+                <form action="register" method="POST">
+                    <p>Insira seu nome e senha para registrar!</p>
+                    Name: <input type="text" name="name"/>
+                    <br/>
+                    Password: <input type="text" name="password"/>
+                    <br/>
+                    <input type="submit" value="Add"/>
+                </form>
+                </body>
+            </html>
+            """
+        elif method == 'POST':
+            new_dict = parse_qs(data)
+            username = new_dict['name'][0]
+            password = new_dict['password'][0]
+            auth = base64.encodestring('%s:%s' % (username, password)).replace('\n', '') 
+            listtoinsert = []
+            listtoinsert.append(username)
+            listtoinsert.append(auth)
+            con = lite.connect('datas.db')
+            with con:
+                cur = con.cursor()
+                cur.execute('INSERT INTO Users(Name,Password) VALUES(?,?)', listtoinsert)
+
+
      
-    if resource == '/notes':
+    elif resource == '/notes':
         response += 'Content-Type: text/plain; charset=utf-8\r\n'
         response += '\r\n'
         for name in note_dict:
             response += '%s\n' % name
+        #for count in range(0,len(note_list)):
+        #    response += str(count + 1) + '\n'
+        con = lite.connect('datas.db')
+        with con:
+            cur = con.cursor()
+            cur.execute('SELECT Key FROM Notes')
+            while True:
+                rows = cur.fetchone()
+                if rows == None:
+                    break
+                print rows
+                for row in rows:
+                    response += row
+                    response += '\r\n'
+	#print note_dict
+	#print note_list
+	#print note_list[1]    
+
+    elif resource == '/edit_note':
+        response += 'Content-Type: text/html; charset=utf-8\r\n'
+        response += '\r\n'
+        if method == 'GET':
+            con = lite.connect('datas.db')
+            with con:
+                cur = con.cursor()
+                cur.execute('SELECT * FROM Notes;')
+                #con.text_factory = str
+                while True:
+                    row = cur.fetchone()
+                    if row == None:
+                        break
+                    row = list(row)
+                    row = str(row)
+                    print row
+                    print row[0]
+                    #response += row[0], row[1], row[2]
+                    response += row
+                    response +='\r\n'
+            response += """
+            <html>
+                <head>
+                    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+                </head>
+                <body>
+                <form action="edit_note" method="POST">
+                    Qual linha deseja mudar: <input type="text" name="line"/>
+                    <br/>
+                    Name: <input type="text" name="name"/>
+                    <br/>
+                    Content: <input type="text" name="content"/>
+                    <br/>
+                    <input type="submit" value="Add"/>
+                </form>
+                </body>
+            </html>
+            """
+        elif method == 'POST':
+            new_dict = urlparse.parse_qs(data)
+            print new_dict
+            rins1 = new_dict['name'][0]
+            rins2 = new_dict['content'][0]
+            rins3 = new_dict['line'][0]
+            print rins1
+            print rins2
+            print rins3
+            con = lite.connect('datas.db')
+            with con:
+                cur = con.cursor()
+                cur.execute('UPDATE Notes SET Key=:name, Note=:content Where Id=:line', {'name':rins1, 'content':rins2, 'line':rins3})
+
     elif resource == '/add_note':
         response += 'Content-Type: text/html; charset=utf-8\r\n'
         response += '\r\n'
@@ -84,25 +300,83 @@ while True:
             """
         elif method == 'POST':
             while True:
-                if len(data) != int (request_headers['content-length']):
-                    data += conn.recv(1024)
-                else:
-                    break
-            new_dict = urlparse.parse_qs(data)
-            note_dict[new_dict['name'][0]] = new_dict['content'][0]
-            with open('.notes', 'w') as note_file:
-                json.dump(note_dict, note_file)
+		if request_headers['content-type'] != 'application/x-www-form-urlencoded':
+			response = ''
+			response += 'HTTP/1.1 501 Not Implemeted\r\n'
+			response += 'Content-Type: text/html; charset=utf-8\r\n'
+			response += '\r\n'
+			response += """
+			<html>
+				<head>
+					<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+				</head>
+				<body>
+					<h1>ERROR 501<h1>
+				</body>
+			</html>
+			"""
+			data = '1'
+			break
+
+		if len(data) != int (request_headers['content-length']):
+			data += conn.recv(1024)
+		else:
+			break
+	    if data != '1':
+		    new_dict = urlparse.parse_qs(data)
+		    note_dict[new_dict['name'][0]] = new_dict['content'][0]
+		    with open('.notes', 'w') as note_file:
+				json.dump(note_dict, note_file)
+                    
+                    keyins = new_dict['name'][0]
+                    notains = new_dict['content'][0]
+                    listtoinsert = []
+                    listtoinsert.append(keyins)
+                    listtoinsert.append(notains)
+                    con = lite.connect('datas.db')
+                    with con:
+                        cur = con.cursor()
+                        try: 
+                            cur.execute("INSERT INTO Notes(Key,Note) VALUES (?,?);", listtoinsert)
+                        except lite.IntegrityError:
+                            response = ''
+                            response += 'HTTP/1.1 409 Conflict\r\n'
+                            response += 'Content-Type: text/html; charset=utf-8\r\n'
+                            response += '\r\n'
+                            response += """
+                            <html>
+                                <head>
+                                    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+                                </head>
+                                <body>
+                                    <h1>ERROR 409<h1>
+                                </body>
+                            </html>
+                            """
 
     else:
         response += 'Content-Type: text/plain; charset=utf-8\r\n'
         response += '\r\n'
         try:
-            note_match = re.match('^/notes/([a-z]+)$', resource)
+            note_match = re.match('^/notes/([a-z0-9]+)$', resource)
+            #print note_match.group(1)
             if note_match is not None:
-                response += note_dict[note_match.group(1)]
+                if note_match.group(1).isalpha():
+                    response += note_dict[note_match.group(1)]
+                else:
+                    print note_list
+                    response += note_list[int(note_match.group(1))]
+                    con = lite.connect('datas.db')
+                    with con:
+                        cur = con.cursor()
+                        cur.execute('SELECT Note from Notes WHERE Id=:id',{'id': (int(note_match.group(1)) + 1)})
+                        row = cur.fetchone()
+                        print row
+                        response += row[0]
+                        
             else:
                 response += 'Hello World!!!'
-        except KeyError:
+        except (KeyError, IndexError):
             response = ''
             response += 'HTTP/1.1 404 Not Found\r\n'
             response += 'Content-Type: text/html; charset=utf-8\r\n'
@@ -117,7 +391,6 @@ while True:
                 </body>
             </html>
             """
-
     conn.sendall(response)
 
     conn.close()

--- a/webnote.py
+++ b/webnote.py
@@ -281,7 +281,7 @@ while True:
             </html>
             """
         elif method == 'POST':
-            new_dict = urlparse.parse_qs(data)
+            new_dict = parse_qs(data)
             print new_dict
             rins1 = new_dict['name'][0]
             rins2 = new_dict['content'][0]
@@ -339,7 +339,7 @@ while True:
 		else:
 			break
 	    if data != '1':
-		    new_dict = urlparse.parse_qs(data)
+		    new_dict = parse_qs(data)
 		    note_dict[new_dict['name'][0]] = new_dict['content'][0]
 		    with open('.notes', 'w') as note_file:
 				json.dump(note_dict, note_file)

--- a/webnote.py
+++ b/webnote.py
@@ -197,9 +197,25 @@ while True:
             listtoinsert.append(username)
             listtoinsert.append(auth)
             con = lite.connect('datas.db')
-            with con:
-                cur = con.cursor()
-                cur.execute('INSERT INTO Users(Name,Password) VALUES(?,?)', listtoinsert)
+            try:
+                with con:
+                    cur = con.cursor()
+                    cur.execute('INSERT INTO Users(Name,Password) VALUES(?,?)', listtoinsert)
+            except lite.IntegrityError:
+                response = ''
+                response += 'HTTP/1.1 409 Conflict\r\n'
+                response += 'Content-Type: text/html; charset=utf-8\r\n'
+                response += '\r\n'
+                response += """
+                <html>
+                    <head>
+                        <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+                    </head>
+                    <body>
+                        <h1>ERROR 409<h1>
+                    </body>
+                </html>
+                """
 
 
      


### PR DESCRIPTION
As notas postas em /add_note agora estão sendo salvas também em um banco de dados SQLite3. Ao colocar um numero Id em /notes/? (iniciando do zero), as notas também são acessadas; caso não exista a nota com determinado Id error 404, em alguns casos os resultados são 'printados' duplamente no browser pois é mostrado tanto o que se achou em .notes quando no banco de dados. Ao escrever /edit_note, é possivel inserir qual linha (mudando apenas no banco de dados, em .notes já estava mudando sozinho mas resolvi deixar apenas a edição para o banco de dados) se deseja mudar e depois inserir a nova 'key' e 'value' a ser editado no banco de dados. Foi implementado também um /register em que o cliente pode inserir um nome de usuário e senha para se cadastrar no servidor. Seus dados são armazenados no banco de dados porém a senha é codificada em base64, e é essa codificação que se armazena. Acessando /auth, pode-se tentar autenticar com seu usuário e senha inseriondo-os nos campos. Os dados fornecidos são comparados com os quais existem no banco de dados (a senha é comparada em base64encoded) e caso obtenha sucesso, apresenta-se uma página exibindo 'Sucess'; caso contrário, é exibido Error 401. Outros problemas como IntegrityError também foram tratados. Nesses casos, é exibido Error 409.
